### PR TITLE
Fix #25 - Failed to require 'jquery' and 'bootstrap' modules

### DIFF
--- a/gtfs-validator-webapp/index.html
+++ b/gtfs-validator-webapp/index.html
@@ -18,8 +18,8 @@
     <![endif]-->
     <script src="build/build.js"></script>
     <script>
-      jQuery = $ = require('jquery');
-      require('bootstrap');
+      jQuery = $ = require.latest('~jquery');
+      require.latest('~bootstrap');
       require('validation_output');
     </script>
   </head>


### PR DESCRIPTION
modified to pass **require()** function the expected jquery and bootstrap module names

Fixes #25 