### PR TITLE
Fix Travis badge links

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ gtfs-validator
 
 A Java framework for GTFS validation and statistics.
 
-[![Build Status](https://travis-ci.org/laidig/gtfs-validator.svg?branch=master)](https://travis-ci.org/laidig/gtfs-validator) 
+[![Build Status](https://travis-ci.org/conveyal/gtfs-validator.svg?branch=master)](https://travis-ci.org/conveyal/gtfs-validator) 
 
 How is this different than the Google-supported validator?
 =============


### PR DESCRIPTION
Make them point to main Conveyal project, not the laidig fork.

Note that Travis also needs to be turned on for the main Conveyal project at https://travis-ci.org/conveyal/gtfs-validator, otherwise no builds will be activated.