### PR TITLE
Allow Travis to build pull requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: java
 jdk: oraclejdk8
-branches:
-  only:
-    - master
 
 cache:
   directories:


### PR DESCRIPTION
I believe this is a remnant of the laidig fork, which didn't have pull requests (related to https://github.com/conveyal/gtfs-validator/pull/33).

Note that Travis also needs to be turned on for the main Conveyal project at https://travis-ci.org/conveyal/gtfs-validator, otherwise no builds will be activated.