### PR TITLE
Workaround for #17 - Don't serialize bounds

### DIFF
--- a/gtfs-validator-json/src/main/java/com/conveyal/gtfs/validator/json/FeedValidationResult.java
+++ b/gtfs-validator-json/src/main/java/com/conveyal/gtfs/validator/json/FeedValidationResult.java
@@ -6,6 +6,7 @@ import java.util.Collection;
 import java.util.Date;
 
 import com.conveyal.gtfs.model.ValidationResult;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
@@ -60,5 +61,6 @@ public class FeedValidationResult implements Serializable {
 	public Date endDate;
 	
 	/** The bounding box of the stops in this feed */
+	@JsonIgnore // See #17
 	public Rectangle2D bounds;
 }


### PR DESCRIPTION
* java.awt.geom.Rectangle2D.Double#getBounds2D recursively returns a new Rectangle2D, which generates a StackOverflowError.  Avoid this by not serializing the feed bounds to JSON.